### PR TITLE
Make the 'last resort' actually work.

### DIFF
--- a/Cap.pm
+++ b/Cap.pm
@@ -279,7 +279,7 @@ sub Tgetent
 
     my @termcap_path = termcap_path();
 
-    unless ( @termcap_path || $entry )
+    if ( !@termcap_path || !$entry )
     {
 
         # last resort--fake up a termcap from terminfo


### PR DESCRIPTION
Without this patch, terminfo entries were not read from the
corresponding file.  For reference, see [1](http://marc.info/?l=openbsd-tech&m=131728639327606&w=2) and [2](http://marc.info/?l=openbsd-tech&m=139576868725531&w=2).

Tested on OpenBSD.
