### PR TITLE
Fix bug #96695 for Term-Cap: test failure on HP-UX.

### DIFF
--- a/Cap.pm
+++ b/Cap.pm
@@ -236,7 +236,7 @@ sub Tgetent
 
     my @termcap_path = termcap_path();
 
-    if ( !@termcap_path || !$entry )
+    if ( !@termcap_path && !$entry )
     {
 
         # last resort--fake up a termcap from terminfo


### PR DESCRIPTION
The change of if -> unless introduced a logic bug in the TF or FT conditions,
but not TT or FF. Using unless (...), if( ! (...) ) or this here if( !... && !...)
restores the previous logic.