### PR TITLE
Remove indirect method calls from documentation

### DIFF
--- a/Cap.pm
+++ b/Cap.pm
@@ -33,7 +33,7 @@ Term::Cap - Perl termcap interface
 =head1 SYNOPSIS
 
     require Term::Cap;
-    $terminal = Tgetent Term::Cap { TERM => undef, OSPEED => $ospeed };
+    $terminal = Term::Cap->Tgetent({ TERM => undef, OSPEED => $ospeed });
     $terminal->Trequire(qw/ce ku kd/);
     $terminal->Tgoto('cm', $col, $row, $FH);
     $terminal->Tputs('dl', $count, $FH);
@@ -702,7 +702,7 @@ sub Trequire
 
     # Get terminal output speed
     require POSIX;
-    my $termios = new POSIX::Termios;
+    my $termios = POSIX::Termios->new;
     $termios->getattr;
     my $ospeed = $termios->getospeed;
 
@@ -712,7 +712,7 @@ sub Trequire
     #     ($ispeed,$ospeed) = unpack('cc',$sgtty);
 
     # allocate and initialize a terminal structure
-    $terminal = Tgetent Term::Cap { TERM => undef, OSPEED => $ospeed };
+    $terminal = Term::Cap->Tgetent({ TERM => undef, OSPEED => $ospeed });
 
     # require certain capabilities to be available
     $terminal->Trequire(qw/ce ku kd/);


### PR DESCRIPTION
Indirect object syntax should not be recommended. See https://metacpan.org/pod/indirect#REFERENCES