### PR TITLE
Prevent unintended parse

### DIFF
--- a/Cap.pm
+++ b/Cap.pm
@@ -91,7 +91,7 @@ sub termcap_path
     {
 
         # Add the users $TERMPATH
-        push( @termcap_path, split( /(:|\s+)/, $ENV{TERMPATH} ) );
+        push( @termcap_path, split( /:|\s+/, $ENV{TERMPATH} ) );
     }
     else
     {


### PR DESCRIPTION
The termcap_path subroutine uses split with a capture on the colon or space
delimited files in `$ENV{TERMPATH}`.

This includes the separator in the split output. These elements are usually
removed by the last line of the subroutine:

    return grep { defined $_ && -f $_ } @termcap_path;

However if a colon-delimited TERMPATH was provided and the file ":" exists,
Term::Cap will attempt to parse it.

This (low) risk is prevented, and the code made more efficient by not
using a capture in the split.

Thanks