### PR TITLE
Drop using old ' package separator

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -121,7 +121,7 @@ SKIP: {
         $ENV{TERMPATH} = '!';
         $ENV{TERMCAP} = '';
         eval { $t = Term::Cap->Tgetent($vals) };
-        isn't( $@, '', 'Tgetent() should catch bad termcap file' );
+        isnt( $@, '', 'Tgetent() should catch bad termcap file' );
 }
 
 SKIP: {


### PR DESCRIPTION
Future perls might drop the usage of ' as a package separator and isnt is perfectly fine to use instead.