### PR TITLE
Makefile.PL - Fix INSTALLDIRS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     'NAME'		=> 'Term::Cap',
     'VERSION_FROM'	=> 'Cap.pm',
-    'INSTALLDIRS'       => 'perl',
+    'INSTALLDIRS'       => ($] < 5.012) ? "perl" : "site",
     'PREREQ_PM'		=> {Test::More => 0.33 },
     'LICENSE'      => 'perl',
     META_MERGE => {


### PR DESCRIPTION
INSTALLDIRS should not be set to "perl" in perl versions newer than 5.12, because site will take precedence.