### PR TITLE
Increase max search depth in termcap

### DIFF
--- a/Cap.pm
+++ b/Cap.pm
@@ -280,7 +280,7 @@ sub Tgetent
 
     $first = 0;    # first entry (keeps term name)
 
-    $max = 32;     # max :tc=...:'s
+    $max = 64;     # max :tc=...:'s
 
     if ($entry)
     {


### PR DESCRIPTION
With the recent import of the new version of ncurses, OpenBSD's /etc/termcap has now grown to need a search depth of at least 36. Since the limit of 32 has worked since perl 5.001 in 1995, hopefully doubling it will get us another 28 years.